### PR TITLE
Implement VerifiedBeacons in scraper

### DIFF
--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -10,6 +10,8 @@
 
 using namespace NN;
 
+extern std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
+
 std::string ExtractXML(const std::string& XMLdata, const std::string& key, const std::string& key_end);
 
 namespace {
@@ -532,6 +534,8 @@ Superblock Superblock::FromConvergence(
 
         projects.SetHint(project_name, part_data);
     }
+
+    superblock.m_verified_beacons = GetVerifiedBeaconIDs(stats.Convergence);
 
     return superblock;
 }

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1208,7 +1208,7 @@ public:
 
         READWRITE(m_cpids);
         READWRITE(m_projects);
-        //READWRITE(m_verified_beacons);
+        READWRITE(m_verified_beacons);
     }
 
     //!

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -3957,7 +3957,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
         manifest->BeaconList = iPartNum;
         manifest->BeaconList_c = 0;
 
-        CDataStream part(vchData, SER_NETWORK, 1);
+        CDataStream part(std::move(vchData), SER_NETWORK, 1);
 
         manifest->addPartData(std::move(part));
 
@@ -3990,8 +3990,6 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
             manifest->projects.push_back(ProjectEntry);
 
             CDataStream part(SER_NETWORK, 1);
-
-            WriteCompactSize(part, ScraperVerifiedBeacons.mVerifiedMap.size());
 
             part << ScraperVerifiedBeacons.mVerifiedMap;
 
@@ -4866,9 +4864,9 @@ std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConverg
 
         for (const auto& entry : VerifiedBeaconMap)
         {
-            CPubKey PubKey;
+            CKeyID KeyID;
 
-            CKeyID KeyID = PubKey.Parse(entry.first).GetID();
+            KeyID.SetHex(entry.first);
 
             result.push_back(KeyID);
         }

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -122,6 +122,7 @@ bool IsScraperMaximumManifestPublishingRateExceeded(int64_t& nTime, CPubKey& Pub
 NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, bool bContractDirectFromStatsUpdate = false);
 bool ScraperSynchronizeDPOR();
 scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperblock, bool bUseCache = true, unsigned int nReducedCacheBits = 32);
+std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
 
 static std::vector<std::string> vstatsobjecttypestrings = { "NetWorkWide", "byCPID", "byProject", "byCPIDbyProject" };
 


### PR DESCRIPTION
This covers most of the bases and should leave you with only filling in anything I may have forgotten. I have done the serialization to put the VerifiedBeacons map as a "project" part in ScraperSendFileManifestContent, and I have implemented the deserialization in the ConvergedManifest from received manifests. I have also put in the plumbing to fill out the vector of verified beacons in the SB.

Note that the serialization/deserialization is a native serialization of the mVerifiedMap, and I felt it was unnecessary to use any of the heavyweight gzip compression/decompression. Note that I also felt it was unnecessary to persist the VerifiedBeacons map to a file.