### PR TITLE
Implement verified beacons in superblock validation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2644,7 +2644,7 @@ bool TryLoadSuperblock(
         }
 
         NN::GetBeaconRegistry().ActivatePending(
-            superblock->m_verified_beacons,
+            superblock->m_verified_beacons.m_verified,
             superblock.m_timestamp);
     }
 

--- a/src/neuralnet/contract/contract.cpp
+++ b/src/neuralnet/contract/contract.cpp
@@ -332,7 +332,7 @@ void NN::ReplayContracts(const CBlockIndex* pindex)
             }
 
             GetBeaconRegistry().ActivatePending(
-                block.GetSuperblock().m_verified_beacons,
+                block.GetSuperblock().m_verified_beacons.m_verified,
                 block.GetBlockTime());
         }
     }

--- a/src/neuralnet/quorum.cpp
+++ b/src/neuralnet/quorum.cpp
@@ -14,8 +14,8 @@
 using namespace NN;
 
 // TODO: use a header
-ScraperStats GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
-ScraperStats GetScraperStatsFromSingleManifest(CScraperManifest &manifest);
+ScraperStatsAndVerifiedBeacons  GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
+ScraperStatsAndVerifiedBeacons  GetScraperStatsFromSingleManifest(CScraperManifest &manifest);
 unsigned int NumScrapersForSupermajority(unsigned int nScraperCount);
 mmCSManifestsBinnedByScraper ScraperCullAndBinCScraperManifests();
 Superblock ScraperGetSuperblockContract(
@@ -782,9 +782,9 @@ private: // SuperblockValidator classes
         //!
         QuorumHash ComputeQuorumHash() const
         {
-            const ScraperStats stats = GetScraperStatsByConvergedManifest(m_convergence);
+            const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetScraperStatsByConvergedManifest(m_convergence);
 
-            return QuorumHash::Hash(stats);
+            return QuorumHash::Hash(stats_and_verified_beacons);
         }
 
     private:
@@ -1314,9 +1314,9 @@ private: // SuperblockValidator methods
     //!
     bool TryManifest(CScraperManifest& manifest) const
     {
-        const ScraperStats stats = GetScraperStatsFromSingleManifest(manifest);
+        const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetScraperStatsFromSingleManifest(manifest);
 
-        return QuorumHash::Hash(stats) == m_quorum_hash;
+        return QuorumHash::Hash(stats_and_verified_beacons) == m_quorum_hash;
     }
 
     //!

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -268,6 +268,8 @@ private:
             {
                 uint160 key_id;
 
+                m_hasher << COMPACTSIZE(stats_and_verified_beacons.mVerifiedMap.size());
+
                 for (const auto& entry_pair : stats_and_verified_beacons.mVerifiedMap) {
                     key_id.SetHex(entry_pair.first);
                     m_hasher << key_id;

--- a/src/neuralnet/superblock.cpp
+++ b/src/neuralnet/superblock.cpp
@@ -266,7 +266,12 @@ private:
             //!
             void Add(const ScraperStatsAndVerifiedBeacons& stats_and_verified_beacons)
             {
-                m_hasher << stats_and_verified_beacons.mVerifiedMap;
+                uint160 key_id;
+
+                for (const auto& entry_pair : stats_and_verified_beacons.mVerifiedMap) {
+                    key_id.SetHex(entry_pair.first);
+                    m_hasher << key_id;
+                }
             }
 
             //!

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1173,7 +1173,7 @@ public:
 
         VerifiedBeacons() {};
 
-        void Add(const ScraperStatsAndVerifiedBeacons& stats_and_verified_beacons);
+        void Reset(const ScraperPendingBeaconMap& verified_beacon_id_map);
 
         ADD_SERIALIZE_METHODS;
 

--- a/src/neuralnet/superblock.h
+++ b/src/neuralnet/superblock.h
@@ -1175,34 +1175,12 @@ public:
 
         void Add(const ScraperStatsAndVerifiedBeacons& stats_and_verified_beacons);
 
-        template<typename Stream>
-        void Serialize(Stream& stream) const
+        ADD_SERIALIZE_METHODS;
+
+        template <typename Stream, typename Operation>
+        inline void SerializationOp(Stream& s, Operation ser_action)
         {
-            if (!(stream.GetType() & SER_GETHASH)) {
-                WriteCompactSize(stream, m_verified.size());
-            }
-
-            for (const auto& iter : m_verified)
-            {
-                stream << iter;
-            }
-        }
-
-        template<typename Stream>
-        void Unserialize(Stream& stream)
-        {
-            m_verified.clear();
-
-            const uint64_t verified_beacon_count = ReadCompactSize(stream);
-            m_verified.reserve(verified_beacon_count);
-
-            for (uint64_t i = 0; i < verified_beacon_count; i++)
-            {
-                uint160 beacon_key_id;
-                stream >> beacon_key_id;
-
-                m_verified.emplace_back(std::move(beacon_key_id));
-            }
+            READWRITE(m_verified);
         }
     };
 

--- a/src/scraper/fwd.h
+++ b/src/scraper/fwd.h
@@ -130,6 +130,57 @@ struct ScraperObjectStatsKeyComp
 
 typedef std::map<ScraperObjectStatsKey, ScraperObjectStats, ScraperObjectStatsKeyComp> ScraperStats;
 
+// This is modeled after AppCacheEntry/Section but named separately.
+struct ScraperBeaconEntry
+{
+    std::string value; //!< Value of entry.
+    int64_t timestamp; //!< Timestamp of entry.
+};
+
+typedef std::map<std::string, ScraperBeaconEntry> ScraperBeaconMap;
+
+struct ScraperPendingBeaconEntry
+{
+    std::string cpid;
+    int64_t timestamp;
+
+    template<typename Stream>
+    void Serialize(Stream& stream) const
+    {
+        stream << cpid;
+        stream << timestamp;
+    }
+
+    template<typename Stream>
+    void Unserialize(Stream& stream)
+    {
+        stream >> cpid;
+        stream >> timestamp;
+    }
+};
+
+typedef std::map<std::string, ScraperPendingBeaconEntry> ScraperPendingBeaconMap;
+
+struct BeaconConsensus
+{
+    uint256 nBlockHash;
+    ScraperBeaconMap mBeaconMap;
+    ScraperPendingBeaconMap mPendingMap;
+};
+
+struct ScraperVerifiedBeacons
+{
+    // Initialize the timestamp to the current adjusted time.
+    int64_t timestamp = GetAdjustedTime();
+    ScraperPendingBeaconMap mVerifiedMap;
+};
+
+struct ScraperStatsAndVerifiedBeacons
+{
+    ScraperStats mScraperStats;
+    ScraperPendingBeaconMap mVerifiedMap;
+};
+
 // Extended AppCache structures similar to those in AppCache.h, except a deleted flag is provided
 struct AppCacheEntryExt
 {

--- a/src/scraper/scraper.cpp
+++ b/src/scraper/scraper.cpp
@@ -275,6 +275,7 @@ void UpdateVerifiedBeaconsFromConsensus(BeaconConsensus& Consensus)
     unsigned int now_active = 0;
 
     LOCK(cs_VerifiedBeacons);
+    _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
     ScraperVerifiedBeacons& ScraperVerifiedBeacons = GetVerifiedBeacons();
 
@@ -299,6 +300,8 @@ void UpdateVerifiedBeaconsFromConsensus(BeaconConsensus& Consensus)
         _log(logattribute::INFO, "UpdateVerifiedBeaconsFromConsensus", std::to_string(now_active)
              + " verified beacons now active and removed from verified beacon map.");
     }
+
+    _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
 }
 } // anonymous namespace
 
@@ -988,9 +991,9 @@ void Scraper(bool bSingleShot)
                 fs::path plogfile_out;
 
                 if (log.archive(false, plogfile_out))
+                {
                     _log(logattribute::INFO, "Scraper", "Archived scraper.log to " + plogfile_out.filename().string());
-
-                //log.closelogfile();
+                }
 
                 sbage = SuperblockAge();
                 _log(logattribute::INFO, "Scraper", "Superblock not needed. age=" + std::to_string(sbage));
@@ -2062,6 +2065,7 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
     }
 
     LOCK(cs_VerifiedBeacons);
+    _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
     ScraperVerifiedBeacons& ScraperVerifiedBeacons = GetVerifiedBeacons();
 
@@ -2144,6 +2148,8 @@ bool ProcessProjectRacFileByCPID(const std::string& project, const fs::path& fil
         }
         else
             builder.append(line);
+
+        _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
     }
 
     if (bfileerror)
@@ -3181,11 +3187,10 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByConsensusBeaconList()
 
     // Since this function uses the current project files for statistics, it also makes sense to use the current verified beacons map.
 
-    ScraperVerifiedBeacons verified_beacons;
-
     LOCK(cs_VerifiedBeacons);
+    _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
-    verified_beacons = GetVerifiedBeacons();
+    ScraperVerifiedBeacons& verified_beacons = GetVerifiedBeacons();
 
     ScraperStatsAndVerifiedBeacons stats_and_verified_beacons;
 
@@ -3193,6 +3198,8 @@ ScraperStatsAndVerifiedBeacons GetScraperStatsByConsensusBeaconList()
     stats_and_verified_beacons.mVerifiedMap = verified_beacons.mVerifiedMap;
 
     _log(logattribute::INFO, "GetScraperStatsByConsensusBeaconList", "Completed stats processing");
+
+    _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
 
     return stats_and_verified_beacons;
 }
@@ -3975,6 +3982,7 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
     // because it will never match any whitelisted project. Only include it if it is not empty.
     {
         LOCK(cs_VerifiedBeacons);
+        _log(logattribute::INFO, "LOCK", "cs_VerifiedBeacons");
 
         ScraperVerifiedBeacons& ScraperVerifiedBeacons = GetVerifiedBeacons();
 
@@ -4003,6 +4011,8 @@ bool ScraperSendFileManifestContents(CBitcoinAddress& Address, CKey& Key)
 
             iPartNum++;
         }
+
+        _log(logattribute::INFO, "ENDLOCK", "cs_VerifiedBeacons");
     }
 
 

--- a/src/scraper/scraper.h
+++ b/src/scraper/scraper.h
@@ -114,7 +114,7 @@ CCriticalSection cs_mScrapersExt;
 *********************/
 
 uint256 GetFileHash(const fs::path& inputfile);
-ScraperStats GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
+ScraperStatsAndVerifiedBeacons GetScraperStatsByConvergedManifest(const ConvergedManifest& StructConvergedManifest);
 std::string ExplainMagnitude(std::string sCPID);
 bool IsScraperAuthorized();
 bool IsScraperAuthorizedToBroadcastManifests(CBitcoinAddress& AddressOut, CKey& KeyOut);
@@ -123,6 +123,8 @@ NN::Superblock ScraperGetSuperblockContract(bool bStoreConvergedStats = false, b
 bool ScraperSynchronizeDPOR();
 scraperSBvalidationtype ValidateSuperblock(const NN::Superblock& NewFormatSuperblock, bool bUseCache = true, unsigned int nReducedCacheBits = 32);
 std::vector<uint160> GetVerifiedBeaconIDs(const ConvergedManifest& StructConvergedManifest);
+std::vector<uint160> GetVerifiedBeaconIDs(const ScraperPendingBeaconMap& VerifiedBeaconMap);
+ScraperStatsAndVerifiedBeacons GetScraperStatsAndVerifiedBeacons(const ConvergedScraperStats &stats);
 
 static std::vector<std::string> vstatsobjecttypestrings = { "NetWorkWide", "byCPID", "byProject", "byCPIDbyProject" };
 

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -883,7 +883,8 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream)
         << meta.project2
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
-        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << std::vector<uint160> {};                     // Verified beacons
 
     NN::Superblock superblock = NN::Superblock::FromConvergence(GetTestConvergence(meta));
 
@@ -927,7 +928,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream)
         << meta.project2
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
-        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << std::vector<uint160> {};                     // Verified beacons
 
     NN::Superblock superblock;
     stream >> superblock;
@@ -1004,7 +1006,8 @@ BOOST_AUTO_TEST_CASE(it_serializes_to_a_stream_for_fallback_convergences)
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
         << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
-        << uint32_t{0xd3591376};                        // Convergence hint
+        << uint32_t{0xd3591376}                         // Convergence hint
+        << std::vector<uint160> {};                     // Verified beacons
 
     NN::Superblock superblock = NN::Superblock::FromConvergence(
         GetTestConvergence(meta, true)); // Set fallback by project flag
@@ -1054,7 +1057,8 @@ BOOST_AUTO_TEST_CASE(it_deserializes_from_a_stream_for_fallback_convergence)
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
         << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
-        << uint32_t{0xd3591376};                        // Convergence hint
+        << uint32_t{0xd3591376}                         // Convergence hint
+        << std::vector<uint160> {};                     // Verified beacons
 
     NN::Superblock superblock;
     stream >> superblock;

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -281,9 +281,9 @@ struct ScraperStatsMeta
 //!
 //! \param meta Contains the values to initialize the scraper stats object with.
 //!
-ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
+const ScraperStatsAndVerifiedBeacons GetTestScraperStats(const ScraperStatsMeta& meta)
 {
-    ScraperStats stats;
+    ScraperStatsAndVerifiedBeacons stats_and_verified_beacons;
 
     ScraperObjectStats p1c1;
     p1c1.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -292,7 +292,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p1c1.statsvalue.dRAC = meta.p1c1_rac;
     p1c1.statsvalue.dAvgRAC = meta.p1c1_avg_rac;
     p1c1.statsvalue.dMag = meta.p1c1_mag;
-    stats.emplace(p1c1.statskey, p1c1);
+    stats_and_verified_beacons.mScraperStats.emplace(p1c1.statskey, p1c1);
 
     ScraperObjectStats p1c2;
     p1c2.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -301,7 +301,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p1c2.statsvalue.dRAC = meta.p1c2_rac;
     p1c2.statsvalue.dAvgRAC = meta.p1c2_avg_rac;
     p1c2.statsvalue.dMag = meta.p1c2_mag;
-    stats.emplace(p1c2.statskey, p1c2);
+    stats_and_verified_beacons.mScraperStats.emplace(p1c2.statskey, p1c2);
 
     ScraperObjectStats p2c1;
     p2c1.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -310,7 +310,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p2c1.statsvalue.dRAC = meta.p2c1_rac;
     p2c1.statsvalue.dAvgRAC = meta.p2c1_avg_rac;
     p2c1.statsvalue.dMag = meta.p2c1_mag;
-    stats.emplace(p2c1.statskey, p2c1);
+    stats_and_verified_beacons.mScraperStats.emplace(p2c1.statskey, p2c1);
 
     ScraperObjectStats p2c2;
     p2c2.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -319,7 +319,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p2c2.statsvalue.dRAC = meta.p2c2_rac;
     p2c2.statsvalue.dAvgRAC = meta.p2c2_avg_rac;
     p2c2.statsvalue.dMag = meta.p2c2_mag;
-    stats.emplace(p2c2.statskey, p2c2);
+    stats_and_verified_beacons.mScraperStats.emplace(p2c2.statskey, p2c2);
 
     ScraperObjectStats p1c3;
     p1c3.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -328,7 +328,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p1c3.statsvalue.dRAC = meta.p1c3_rac;
     p1c3.statsvalue.dAvgRAC = meta.p1c3_avg_rac;
     p1c3.statsvalue.dMag = meta.p1c3_mag;
-    stats.emplace(p1c2.statskey, p1c3);
+    stats_and_verified_beacons.mScraperStats.emplace(p1c2.statskey, p1c3);
 
     ScraperObjectStats p2c3;
     p2c3.statskey.objecttype = statsobjecttype::byCPIDbyProject;
@@ -337,7 +337,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p2c3.statsvalue.dRAC = meta.p2c3_rac;
     p2c3.statsvalue.dAvgRAC = meta.p2c3_avg_rac;
     p2c3.statsvalue.dMag = meta.p2c3_mag;
-    stats.emplace(p2c2.statskey, p2c3);
+    stats_and_verified_beacons.mScraperStats.emplace(p2c2.statskey, p2c3);
 
     ScraperObjectStats c1;
     c1.statskey.objecttype = statsobjecttype::byCPID;
@@ -346,7 +346,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     c1.statsvalue.dRAC = meta.c1_rac;
     c1.statsvalue.dAvgRAC = meta.c1_rac;
     c1.statsvalue.dMag = meta.c1_mag;
-    stats.emplace(c1.statskey, c1);
+    stats_and_verified_beacons.mScraperStats.emplace(c1.statskey, c1);
 
     ScraperObjectStats c2;
     c2.statskey.objecttype = statsobjecttype::byCPID;
@@ -355,7 +355,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     c2.statsvalue.dRAC = meta.c2_rac;
     c2.statsvalue.dAvgRAC = meta.c2_rac;
     c2.statsvalue.dMag = meta.c2_mag;
-    stats.emplace(c2.statskey, c2);
+    stats_and_verified_beacons.mScraperStats.emplace(c2.statskey, c2);
 
     ScraperObjectStats c3;
     c3.statskey.objecttype = statsobjecttype::byCPID;
@@ -364,7 +364,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     c3.statsvalue.dRAC = meta.c3_rac;
     c3.statsvalue.dAvgRAC = meta.c3_rac;
     c3.statsvalue.dMag = meta.c3_mag;
-    stats.emplace(c3.statskey, c3);
+    stats_and_verified_beacons.mScraperStats.emplace(c3.statskey, c3);
 
     ScraperObjectStats p1;
     p1.statskey.objecttype = statsobjecttype::byProject;
@@ -373,7 +373,7 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p1.statsvalue.dRAC = meta.p1_rac;
     p1.statsvalue.dAvgRAC = meta.p1_avg_rac;
     p1.statsvalue.dMag = meta.p1_mag;
-    stats.emplace(p1.statskey, p1);
+    stats_and_verified_beacons.mScraperStats.emplace(p1.statskey, p1);
 
     ScraperObjectStats p2;
     p2.statskey.objecttype = statsobjecttype::byProject;
@@ -382,9 +382,11 @@ ScraperStats GetTestScraperStats(const ScraperStatsMeta& meta)
     p2.statsvalue.dRAC = meta.p2_rac;
     p2.statsvalue.dAvgRAC = meta.p2_avg_rac;
     p2.statsvalue.dMag = meta.p2_mag;
-    stats.emplace(p2.statskey, p2);
+    stats_and_verified_beacons.mScraperStats.emplace(p2.statskey, p2);
 
-    return stats;
+    //TODO: Put in verified beacon map.
+
+    return stats_and_verified_beacons;
 }
 
 //!
@@ -399,7 +401,7 @@ ConvergedScraperStats GetTestConvergence(
 {
     ConvergedScraperStats convergence;
 
-    convergence.mScraperConvergedStats = GetTestScraperStats(meta);
+    convergence.mScraperConvergedStats = GetTestScraperStats(meta).mScraperStats;
 
     convergence.Convergence.bByParts = by_parts;
     convergence.Convergence.nContentHash
@@ -412,6 +414,8 @@ ConvergedScraperStats GetTestConvergence(
     //
     convergence.Convergence.ConvergedManifestPartsMap.emplace("project_1", CSerializeData());
     convergence.Convergence.ConvergedManifestPartsMap.emplace("project_2", CSerializeData());
+
+    //TODO: should we add a VerifiedBeacons project here?
 
     return convergence;
 }
@@ -1942,10 +1946,10 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
 BOOST_AUTO_TEST_CASE(it_hashes_a_set_of_scraper_statistics_like_a_superblock)
 {
     const ScraperStatsMeta meta;
-    const ScraperStats stats = GetTestScraperStats(meta);
+    const ScraperStatsAndVerifiedBeacons stats_and_verified_beacons = GetTestScraperStats(meta);
 
-    NN::Superblock superblock = NN::Superblock::FromStats(stats);
-    NN::QuorumHash quorum_hash = NN::QuorumHash::Hash(stats);
+    NN::Superblock superblock = NN::Superblock::FromStats(stats_and_verified_beacons);
+    NN::QuorumHash quorum_hash = NN::QuorumHash::Hash(stats_and_verified_beacons);
 
     BOOST_CHECK(quorum_hash == superblock.GetHash());
 }

--- a/src/test/neuralnet/superblock_tests.cpp
+++ b/src/test/neuralnet/superblock_tests.cpp
@@ -1934,7 +1934,8 @@ BOOST_AUTO_TEST_CASE(it_hashes_a_superblock)
         << meta.project2
         << VARINT((uint64_t)std::nearbyint(meta.p2_tc))
         << VARINT((uint64_t)std::nearbyint(meta.p2_avg_rac))
-        << VARINT((uint64_t)std::nearbyint(meta.p2_rac));
+        << VARINT((uint64_t)std::nearbyint(meta.p2_rac))
+        << std::vector<uint160> {};                     // Verified beacons
 
     const uint256 expected = expected_hasher.GetHash();
 
@@ -2093,7 +2094,8 @@ BOOST_AUTO_TEST_CASE(it_compares_a_sha256_hash_for_equality)
             << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash()
             << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash())
             .GetHash()
-        << VARINT(uint32_t{0}); // Zero-magnitude count
+        << VARINT(uint32_t{0})      // Zero-magnitude count
+        << std::vector<uint160> {}; // Verified beacons
 
     // Hashed byte content of an empty superblock. Note that container sizes
     // are not considered in the hash:
@@ -2119,7 +2121,8 @@ BOOST_AUTO_TEST_CASE(it_compares_a_string_for_equality)
             << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash()
             << CHashWriter(SER_GETHASH, PROTOCOL_VERSION).GetHash())
             .GetHash()
-        << VARINT(uint32_t{0}); // Zero-magnitude count
+        << VARINT(uint32_t{0})      // Zero-magnitude count
+        << std::vector<uint160> {}; // Verified beacons
 
     // Hashed byte content of an empty superblock. Note that container sizes
     // are not considered in the hash:


### PR DESCRIPTION
This is nearly complete I think. You may not like everything I did. Feel free to change things.

The overall concept here was to replace the scraper stats map with a struct that returns both the stats map and the verified beacons map.

Had to do a lot of work in the mock stuff, fromStats, and had to wrap the std::vector<uint160> m_verified_beacons in a struct to get everything to compile.

The test suite still is giving errors, but I haven't fixed that.
